### PR TITLE
README Typo: folked > forked

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Full documentation for this project is available at [yezyilomo.github.io/state-p
 
 
 ## Running Tests
-If you've folked this library and you want to run tests use the following command
+If you've forked this library and you want to run tests use the following command
 
 ```sh
 npm test


### PR DESCRIPTION
Small typo on [README.md](https://github.com/yezyilomo/state-pool/blob/master/README.md)