### PR TITLE
Implement a new way to derive state by calling select method on a global state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
-import { GlobalState, createGlobalstate } from './GlobalState';
+import { GlobalState, DerivedGlobalState, createGlobalstate } from './GlobalState';
 import { Store, createStore } from './Store';
 import { useGlobalStateReducer } from './useGlobalStateReducer'
 import { useGlobalState } from './useGlobalState'
 
 
 export {
-    GlobalState, createGlobalstate, Store, createStore,
-    useGlobalStateReducer, useGlobalState
+    GlobalState, DerivedGlobalState, createGlobalstate, Store,
+    createStore, useGlobalStateReducer, useGlobalState
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+type Selector<T> = (state: any) => T
+type Patcher = (state: any, selectedStateValue: any) => void
+type Reducer = (state: any, action: any) => any
+type HookConfig = { patcher?: Patcher, selector?: Selector<any> }
+type Unsubscribe = () => void
+
+
+export {
+    Selector, Patcher, Reducer, HookConfig, Unsubscribe
+}

--- a/src/useGlobalState.ts
+++ b/src/useGlobalState.ts
@@ -1,13 +1,9 @@
 import { GlobalState } from './GlobalState';
+import { HookConfig } from './types';
 import { useGlobalStateReducer } from './useGlobalStateReducer';
 
 
-type Config = {
-    selector?: (state: any) => any,
-    patcher?: (state: any, selectedStateValue: any) => any
-}
-
-type ReturnType<T> = [
+type HookReturnType<T> = [
     state: T,
     setState: (state: any) => any,
     updateState: (
@@ -17,8 +13,8 @@ type ReturnType<T> = [
 
 function useGlobalState<T>(
     globalState: GlobalState<any>,
-    config: Config = {},
-): ReturnType<T> {
+    config: HookConfig = {},
+): HookReturnType<T> {
     function reducer(currentState: any, newState: any) {
         return newState;
     }

--- a/src/useGlobalStateReducer.ts
+++ b/src/useGlobalStateReducer.ts
@@ -1,24 +1,18 @@
 import { useState, useEffect, useRef } from 'react';
 import { GlobalState } from './GlobalState';
+import { HookConfig, Reducer } from './types';
 
 
-type Reducer = (state: any, action: any) => any
-
-type Config = {
-    selector?: (state: any) => any,
-    patcher?: (state: any, selectedStateValue: any) => any
-}
-
-type ReturnType<T> = [
+type HookReturnType<T> = [
     state: T,
     dispatch: (action: any) => any
 ]
 
-function useGlobalStateReducer<T=any>(
+function useGlobalStateReducer<T = any>(
     reducer: Reducer,
     globalState: GlobalState<any>,
-    config: Config = {}
-): ReturnType<T> {
+    config: HookConfig = {}
+): HookReturnType<T> {
     const [, setState] = useState(null);
     const isMounted = useRef(false);
 
@@ -45,7 +39,7 @@ function useGlobalStateReducer<T=any>(
         selector: config.selector ?
             config.selector :
             (state) => state,  // Select the whole global state if selector is not specified
-        reRender: reRender
+        refresh: reRender
     }
 
     useEffect(() => {

--- a/tests/subscription.test.ts
+++ b/tests/subscription.test.ts
@@ -1,27 +1,63 @@
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { createStore } from '../src/';
+import { createGlobalstate, useGlobalState, createStore } from '../src/';
 
 
-const store = createStore();
-store.setState("count", 0);
+const count = createGlobalstate(0);
 
 let testVal1 = 0;
-let testVal2 = 0;
 
-test('should update testVal1 & testVal2 through subscribers', () => {
-    const { result } = renderHook(() => store.useState("count"))
+test('should update testVal1 through a subscriber', () => {
+    const { result } = renderHook(() => useGlobalState(count))
 
     act(() => {
-        store.subscribe((key, value) => {
-            testVal1 = 1
-        })
-        store.getState("count").subscribe((value) => {
-            testVal2 = 2
+        count.subscribe((value) => {
+            testVal1 = ++testVal1;
         })
         result.current[1](count => 1)
     })
 
     expect(testVal1).toStrictEqual(1);
+})
+
+
+const user = createGlobalstate({ name: "Yezy", weight: 65 });
+
+let testVal2 = 0;
+
+test('should increment testVal2 twice through subscribers', () => {
+    const { result } = renderHook(() => useGlobalState(user))
+
+    act(() => {
+        user.select(user => user.weight).subscribe((value) => {
+            testVal2 = ++testVal2;
+        })
+
+        user.select(user => user.name).subscribe((value) => {
+            testVal2 = ++testVal2;
+        })
+
+        result.current[2](user => { user.weight = 66; user.name = "Ilomo"; });
+    })
+
     expect(testVal2).toStrictEqual(2);
+})
+
+
+const store = createStore();
+store.setState("count", 0);
+
+let testVal3 = 0;
+
+test('should update testVal3 through subscribers', () => {
+    const { result } = renderHook(() => store.useState("count"))
+
+    act(() => {
+        store.subscribe((key, value) => {
+            testVal3 = ++testVal3;
+        })
+        result.current[1](count => 1)
+    })
+
+    expect(testVal3).toStrictEqual(1);
 })


### PR DESCRIPTION
With this we'll be able to derive a state by simply calling `.select`

```js
globalState.select(state => state.sub).subscribe(val => {// Do your thing})
```